### PR TITLE
Code::Blocks project: use the msys2's wxWidgets library to build the …

### DIFF
--- a/codeblocks/DXF_ViewerForWxWidgets/DXF_ViewerForWxWidgets.cbp
+++ b/codeblocks/DXF_ViewerForWxWidgets/DXF_ViewerForWxWidgets.cbp
@@ -34,7 +34,6 @@
 			<Add option="-mthreads" />
 			<Add option="`$(#WX_CONFIG) --cflags`" />
 			<Add option="-D__GNUWIN32__" />
-			<Add option="-Dwxwbuild" />
 		</Compiler>
 		<ResourceCompiler>
 			<Add option="`$(#WX_CONFIG) --rcflags`" />

--- a/codeblocks/DXF_ViewerForWxWidgets/DXF_ViewerForWxWidgets.cbp
+++ b/codeblocks/DXF_ViewerForWxWidgets/DXF_ViewerForWxWidgets.cbp
@@ -2,24 +2,23 @@
 <CodeBlocks_project_file>
 	<FileVersion major="1" minor="6" />
 	<Project>
-		<Option title="DXF_Wiewer" />
-		<Option pch_mode="2" />
-		<Option compiler="gcc_v83" />
+		<Option title="DXF_Viewer_wxWidgets" />
+		<Option compiler="gcc" />
 		<Build>
 			<Target title="Debug">
-				<Option output="../../../bin/DXF_Wiewer" prefix_auto="1" extension_auto="1" />
+				<Option output="../../bin/DXF_Viewer_wxWidgets_Debug" prefix_auto="1" extension_auto="1" />
 				<Option object_output="obj/Debug/" />
 				<Option type="1" />
-				<Option compiler="gcc_v83" />
+				<Option compiler="gcc" />
 				<Compiler>
 					<Add option="-g" />
 				</Compiler>
 			</Target>
 			<Target title="Release">
-				<Option output="../../../bin/DXF_Wiewer" prefix_auto="1" extension_auto="1" />
+				<Option output="../../bin/DXF_Viewer_wxWidgets_Release" prefix_auto="1" extension_auto="1" />
 				<Option object_output="obj/Release/" />
 				<Option type="1" />
-				<Option compiler="gcc_v83" />
+				<Option compiler="gcc" />
 				<Compiler>
 					<Add option="-O2" />
 				</Compiler>
@@ -31,55 +30,38 @@
 		<Compiler>
 			<Add option="-Wall" />
 			<Add option="-fexceptions" />
+			<Add option="-pipe" />
+			<Add option="-mthreads" />
+			<Add option="`wx-config-msys2 --cflags --prefix=$(TARGET_COMPILER_DIR)`" />
 			<Add option="-D__GNUWIN32__" />
 			<Add option="-Dwxwbuild" />
-			<Add directory="$(#wxwidgets.include)" />
-			<Add directory="$(#wxwidgets.setup)" />
 		</Compiler>
+		<ResourceCompiler>
+			<Add option="`wx-config-msys2 --rcflags --prefix=$(TARGET_COMPILER_DIR)`" />
+		</ResourceCompiler>
 		<Linker>
-			<Add option="-static-libstdc++" />
-			<Add option="-static-libgcc" />
-			<Add option="-static" />
-			<Add library="wxmsw31u" />
-			<Add library="wxpng" />
-			<Add library="wxzlib" />
-			<Add library="ole32" />
-			<Add library="Comctl32" />
-			<Add library="uuid" />
-			<Add library="OleAut32" />
-			<Add library="Winspool" />
-			<Add library="version" />
-			<Add library="shlwapi" />
-			<Add library="uxtheme" />
-			<Add library="oleacc" />
-			<Add library="gdi32" />
-			<Add library="Comdlg32" />
-			<Add directory="$(#wxwidgets.lib)" />
+			<Add option="-mthreads" />
+			<Add option="`wx-config-msys2 --libs all --prefix=$(TARGET_COMPILER_DIR)`" />
 		</Linker>
-		<Unit filename="../../../src/Arc.cpp" />
-		<Unit filename="../../../src/Arc.h" />
-		<Unit filename="../../../src/Circle.cpp" />
-		<Unit filename="../../../src/Circle.h" />
-		<Unit filename="../../../src/Dimension.cpp" />
-		<Unit filename="../../../src/Dimension.h" />
-		<Unit filename="../../../src/Dxf.cpp" />
-		<Unit filename="../../../src/Dxf.h" />
-		<Unit filename="../../../src/Line.cpp" />
-		<Unit filename="../../../src/Line.h" />
-		<Unit filename="../../../src/PolyLine.cpp" />
-		<Unit filename="../../../src/PolyLine.h" />
-		<Unit filename="../../../src/Solid.cpp" />
-		<Unit filename="../../../src/Spline.cpp" />
-		<Unit filename="../../../src/Spline.h" />
-		<Unit filename="../../../src/StdAfx.h" />
-		<Unit filename="../../../src/Text.cpp" />
-		<Unit filename="../../../src/Text.h" />
-		<Unit filename="../../../src/wxWidgets.cpp" />
-		<Extensions>
-			<code_completion />
-			<envvars />
-			<debugger />
-			<lib_finder disable_auto="1" />
-		</Extensions>
+		<Unit filename="../../src/Arc.cpp" />
+		<Unit filename="../../src/Arc.h" />
+		<Unit filename="../../src/Circle.cpp" />
+		<Unit filename="../../src/Circle.h" />
+		<Unit filename="../../src/Dimension.cpp" />
+		<Unit filename="../../src/Dimension.h" />
+		<Unit filename="../../src/Dxf.cpp" />
+		<Unit filename="../../src/Dxf.h" />
+		<Unit filename="../../src/Line.cpp" />
+		<Unit filename="../../src/Line.h" />
+		<Unit filename="../../src/PolyLine.cpp" />
+		<Unit filename="../../src/PolyLine.h" />
+		<Unit filename="../../src/Solid.cpp" />
+		<Unit filename="../../src/Solid.h" />
+		<Unit filename="../../src/Spline.cpp" />
+		<Unit filename="../../src/Spline.h" />
+		<Unit filename="../../src/Text.cpp" />
+		<Unit filename="../../src/Text.h" />
+		<Unit filename="../../src/wxWidgets.cpp" />
+		<Extensions />
 	</Project>
 </CodeBlocks_project_file>

--- a/codeblocks/DXF_ViewerForWxWidgets/DXF_ViewerForWxWidgets.cbp
+++ b/codeblocks/DXF_ViewerForWxWidgets/DXF_ViewerForWxWidgets.cbp
@@ -32,16 +32,16 @@
 			<Add option="-fexceptions" />
 			<Add option="-pipe" />
 			<Add option="-mthreads" />
-			<Add option="`wx-config-msys2 --cflags --prefix=$(TARGET_COMPILER_DIR)`" />
+			<Add option="`$(#WX_CONFIG) --cflags`" />
 			<Add option="-D__GNUWIN32__" />
 			<Add option="-Dwxwbuild" />
 		</Compiler>
 		<ResourceCompiler>
-			<Add option="`wx-config-msys2 --rcflags --prefix=$(TARGET_COMPILER_DIR)`" />
+			<Add option="`$(#WX_CONFIG) --rcflags`" />
 		</ResourceCompiler>
 		<Linker>
 			<Add option="-mthreads" />
-			<Add option="`wx-config-msys2 --libs all --prefix=$(TARGET_COMPILER_DIR)`" />
+			<Add option="`$(#WX_CONFIG) --libs all`" />
 		</Linker>
 		<Unit filename="../../src/Arc.cpp" />
 		<Unit filename="../../src/Arc.h" />

--- a/src/Dxf.h
+++ b/src/Dxf.h
@@ -10,9 +10,6 @@
 
 #define MAXPOINTS 1024
 
-#ifdef wxwbuild
-class wxDC;
-#endif // wxwbuild
 #ifdef nanabuild
 namespace nana
 {
@@ -250,18 +247,18 @@ namespace dxfv
 
         /**
          * @brief Parse dxf group code value pairs for an entity
-         * 
+         *
          * @param cvit reference to iterator pointing to first code/value pair to be parsed ( code 0 ! )
          * @return true this should never happen
          * @return false encountered a new entity
-         * 
+         *
          * In the base class this method is undefined.
          * Overide with parser for each entity type.
-         * 
+         *
          * This should work its way through the code value pairs in a .dxf file
          * until a new entity is encountered ( a new code 0 ), parsing the values.
          * When new entity found return false with cvit pointing to new entity 0 code value pair
-         * 
+         *
          */
         virtual bool Append(cvit_t &cvit) = 0;
 
@@ -357,16 +354,6 @@ namespace dxfv
 
         // accessors for graphical device context
         // which depend on the GUI framework used by the build
-#ifdef wxwbuild
-        void DC(wxDC *dc)
-        {
-            myDC = dc;
-        }
-        wxDC *DC()
-        {
-            return myDC;
-        }
-#endif // wxwbuild
 #ifdef nanabuild
         void graph(nana::paint::graphics *g)
         {
@@ -391,10 +378,6 @@ namespace dxfv
 
         /// Vector storing pointers to each parsed entity
         std::vector<cDXFGraphObject *> myGraphObject;
-
-#ifdef wxwbuild
-        wxDC *myDC;
-#endif // wxwbuild
 
 #ifdef nanabuild
         nana::paint::graphics *myGraph;

--- a/src/wxWidgets.cpp
+++ b/src/wxWidgets.cpp
@@ -8,6 +8,10 @@
 
 #include "dxf.h"
 
+// Global pointer to instance of class that uses the wxWidgets library to draw on the window
+
+wxDC * theDC = nullptr;
+
 class dxfv_wxWidgetsApp : public wxApp
 {
 public:
@@ -244,7 +248,7 @@ void dxfv_wxWidgetsFrame::OnSelectSolidParser(wxCommandEvent& event)
 void dxfv_wxWidgetsFrame::OnPaint(wxPaintEvent& event)
 {
     wxPaintDC dc(this);
-    dxf->DC( &dc );
+    theDC = &dc; // set the global wxDC pointer
     dc.SetPen(*wxWHITE_PEN);
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
     dc.SetTextForeground( *wxYELLOW );
@@ -262,6 +266,8 @@ void dxfv_wxWidgetsFrame::OnPaint(wxPaintEvent& event)
 //        dim.getDraw( draw );
 //        dc.DrawText( draw.text, draw.x1, draw.y1 );
 //    }
+
+    theDC = nullptr;
 }
 void dxfv_wxWidgetsFrame::OnSize(wxSizeEvent& event)
 {
@@ -394,9 +400,9 @@ void CLine::Draw( CDxf* dxf )
     while( getDraw( draw ) )
     {
         wxColour c(draw.color);
-        dxf->DC()->SetBrush(wxBrush(c));
-        dxf->DC()->SetPen(wxPen(c));
-        dxf->DC()->DrawLine( draw.x1, draw.y1, draw.x2, draw.y2 );
+        theDC->SetBrush(wxBrush(c));
+        theDC->SetPen(wxPen(c));
+        theDC->DrawLine( draw.x1, draw.y1, draw.x2, draw.y2 );
     }
 }
 void CArc::Draw( CDxf* dxf )
@@ -411,9 +417,9 @@ void CArc::Draw( CDxf* dxf )
         double diameter = 2 * draw.r;
         wxColour c(draw.color);
         // Set the brush to be transparent
-        dxf->DC()->SetBrush(*wxTRANSPARENT_BRUSH);
-        dxf->DC()->SetPen(wxPen(c));
-        dxf->DC()->DrawEllipticArc (
+        theDC->SetBrush(*wxTRANSPARENT_BRUSH);
+        theDC->SetPen(wxPen(c));
+        theDC->DrawEllipticArc (
             xTopLeft, yTopLeft,
             diameter, diameter,
             draw.sa, draw.ea );
@@ -428,9 +434,9 @@ void CCircle::Draw( CDxf* dxf )
     {
         wxColour c(draw.color);
         // Set the brush to be transparent
-        dxf->DC()->SetBrush(*wxTRANSPARENT_BRUSH);
-        dxf->DC()->SetPen(wxPen(c));
-        dxf->DC()->DrawCircle( draw.x1, draw.y1, draw.r );
+        theDC->SetBrush(*wxTRANSPARENT_BRUSH);
+        theDC->SetPen(wxPen(c));
+        theDC->DrawCircle( draw.x1, draw.y1, draw.r );
     }
 }
 void cLWPolyLine::Draw( CDxf* dxf )
@@ -441,9 +447,9 @@ void cLWPolyLine::Draw( CDxf* dxf )
     while( getDraw( draw ) )
     {
         wxColour c(draw.color);
-        dxf->DC()->SetBrush(wxBrush(c));
-        dxf->DC()->SetPen(wxPen(c));
-        dxf->DC()->DrawLine( draw.x1, draw.y1, draw.x2, draw.y2 );
+        theDC->SetBrush(wxBrush(c));
+        theDC->SetPen(wxPen(c));
+        theDC->DrawLine( draw.x1, draw.y1, draw.x2, draw.y2 );
     }
 }
 void CText::Draw( CDxf* dxf )
@@ -454,9 +460,9 @@ void CText::Draw( CDxf* dxf )
     while( getDraw( draw ) )
     {
         wxColour c(draw.color);
-        dxf->DC()->SetBrush(wxBrush(c));
-        dxf->DC()->SetPen(wxPen(c));
-        dxf->DC()->DrawText( draw.text, draw.x1, draw.y1 );
+        theDC->SetBrush(wxBrush(c));
+        theDC->SetPen(wxPen(c));
+        theDC->DrawText( draw.text, draw.x1, draw.y1 );
     }
 }
 void CSpline::Draw( CDxf* dxf )
@@ -465,8 +471,8 @@ void CSpline::Draw( CDxf* dxf )
     cDrawPrimitiveData draw( dxf );
 
     wxColour c(draw.color);
-    dxf->DC()->SetBrush(wxBrush(c));
-    dxf->DC()->SetPen(wxPen(c));
+    theDC->SetBrush(wxBrush(c));
+    theDC->SetPen(wxPen(c));
 
     // loop over drawing primitives
     while( getDraw( draw ) )
@@ -485,7 +491,7 @@ void CSpline::Draw( CDxf* dxf )
             {
                 // all contol points
                 // use wxwidget spline method
-                dxf->DC()->DrawSpline(
+                theDC->DrawSpline(
                     m_ControlPointCount,
                     spline_points );
             }
@@ -494,7 +500,7 @@ void CSpline::Draw( CDxf* dxf )
         {
             // use wxwidgets drawing primitive for spline
 
-            dxf->DC()->DrawLine( draw.x1, draw.y1, draw.x2, draw.y2 );
+            theDC->DrawLine( draw.x1, draw.y1, draw.x2, draw.y2 );
         }
     }
 }
@@ -517,10 +523,10 @@ void CSolid::Draw( CDxf* dxf )
         };
 
         wxColour c(draw.color);
-        dxf->DC()->SetBrush(wxBrush(c));
-        dxf->DC()->SetPen(wxPen(c));
+        theDC->SetBrush(wxBrush(c));
+        theDC->SetPen(wxPen(c));
 
-        dxf->DC()->DrawPolygon(3, points);
+        theDC->DrawPolygon(3, points);
     }
 }
 }


### PR DESCRIPTION
…DXF_Viewer

The compiler name is changed to "gcc".
The wxWidgets library can be obtained by the pacman command, see here: Base Package: mingw-w64-wxwidgets3.2 - MSYS2 Packages — https://packages.msys2.org/base/mingw-w64-wxwidgets3.2 Use the wx-config-msys2.exe to generate the correct compiler options. This tool can be obtained from https://github.com/eranif/wx-config-msys2 Adjust the file path in the cbp.
Add a resource rc file for the project.
I don't think the "StdAfx.h"(the PCH file name for MSVC) file is needed, so I remove it from the cbp file.