### PR TITLE
build fix for the wxWidgets target

### DIFF
--- a/src/wxWidgets.cpp
+++ b/src/wxWidgets.cpp
@@ -238,11 +238,11 @@ void dxfv_wxWidgetsFrame::OnSelectSolidParser(wxCommandEvent& event)
 {
     int id = event.GetId();
     if (id == idMenuSOLID2pointParser)
-        dxf->SolidParser( dxfv::eParser::solid_2point );
+        dxfv::CSolid::parser( dxfv::CSolid::eParser::solid_2point );
     else if (id == idMenuSOLID3pointParser)
-        dxf->SolidParser( dxfv::eParser::solid_3point );
+        dxfv::CSolid::parser( dxfv::CSolid::eParser::solid_3point );
     else if (id == idMenuSOLID4pointParser)
-        dxf->SolidParser( dxfv::eParser::solid_4point );
+        dxfv::CSolid::parser( dxfv::CSolid::eParser::solid_4point );
 }
 
 void dxfv_wxWidgetsFrame::OnPaint(wxPaintEvent& event)


### PR DESCRIPTION
This is because the solid parser options are moved to CSolid class

Hi, James. This is the build fix for the wxWidgets port, I really don't know why my last PR does not fix such issue. Because in the 

Author: JamesBremner <james@ravenspoint.com>
Date: 2024/8/21 1:21:18
Commit hash: 41cbbcbe3b17e67e60dd898202608d6324709e97

move solid parser options to CSolid

You have already change the windex port.

Thanks.